### PR TITLE
Bump up the GuzzleHttp lib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": "~7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Updating the requirement of GuzzleHttp lib to last version to prevent compatibility problems with other libs.

I'd suggest you to bump up version of your lib also and create special tag for that update to keep possible using your lib with other libs that has same different requirements.